### PR TITLE
Modify console export path

### DIFF
--- a/src/server/ServerBuilder/Program.fs
+++ b/src/server/ServerBuilder/Program.fs
@@ -341,5 +341,5 @@ module Program =
         let releaseDir = Path.Combine(workingDir, "..", "..", "..", "Misc", "out") |> Path.GetFullPath
         generateFakeContext(workingDir)
         build(workingDir, releaseDir)
-        Console.WriteLine("Release file written at: " + Path.Combine(releaseDir + Path.DirectorySeparatorChar.ToString(), releaseFilename))
+        Console.WriteLine("Release file written at: " + Path.Combine(releaseDir + Path.DirectorySeparatorChar.ToString() + "Release" + Path.DirectorySeparatorChar.ToString(), releaseFilename))
         0

--- a/src/server/ServerBuilder/Program.fs
+++ b/src/server/ServerBuilder/Program.fs
@@ -341,5 +341,5 @@ module Program =
         let releaseDir = Path.Combine(workingDir, "..", "..", "..", "Misc", "out") |> Path.GetFullPath
         generateFakeContext(workingDir)
         build(workingDir, releaseDir)
-        Console.WriteLine("Release file written at: " + Path.Combine(releaseDir + Path.DirectorySeparatorChar.ToString() + "release" + Path.DirectorySeparatorChar.ToString(), releaseFilename))
+        Console.WriteLine("Release file written at: " + Path.Combine(releaseDir , "release" , releaseFilename))
         0

--- a/src/server/ServerBuilder/Program.fs
+++ b/src/server/ServerBuilder/Program.fs
@@ -341,5 +341,5 @@ module Program =
         let releaseDir = Path.Combine(workingDir, "..", "..", "..", "Misc", "out") |> Path.GetFullPath
         generateFakeContext(workingDir)
         build(workingDir, releaseDir)
-        Console.WriteLine("Release file written at: " + Path.Combine(releaseDir + Path.DirectorySeparatorChar.ToString() + "Release" + Path.DirectorySeparatorChar.ToString(), releaseFilename))
+        Console.WriteLine("Release file written at: " + Path.Combine(releaseDir + Path.DirectorySeparatorChar.ToString() + "release" + Path.DirectorySeparatorChar.ToString(), releaseFilename))
         0


### PR DESCRIPTION
There is just a small mistake in the cmd prompt.
`Release file written at: E:\Tools\Misc\out\Alan.v7.0.518.4.zip`
Insteed of :
`Release file written at: E:\Tools\Misc\out\release\Alan.v7.0.518.4.zip`